### PR TITLE
Fix Zeromorph<IPA> accumulation

### DIFF
--- a/plonkish_backend/src/accumulation/protostar/hyperplonk.rs
+++ b/plonkish_backend/src/accumulation/protostar/hyperplonk.rs
@@ -646,5 +646,5 @@ pub(crate) mod test {
     tests!(gemini_kzg, Gemini<UnivariateKzg<Bn256>>);
     tests!(zeromorph_kzg, Zeromorph<UnivariateKzg<Bn256>>);
     tests!(gemini_ipa, Gemini<UnivariateIpa<grumpkin::G1Affine>>);
-    //tests!(zeromorph_ipa, Zeromorph<UnivariateIpa<grumpkin::G1Affine>>);
+    tests!(zeromorph_ipa, Zeromorph<UnivariateIpa<grumpkin::G1Affine>>);
 }

--- a/plonkish_backend/src/accumulation/sangria/hyperplonk.rs
+++ b/plonkish_backend/src/accumulation/sangria/hyperplonk.rs
@@ -58,5 +58,5 @@ pub(crate) mod test {
     tests!(gemini_kzg, Gemini<UnivariateKzg<Bn256>>);
     tests!(zeromorph_kzg, Zeromorph<UnivariateKzg<Bn256>>);
     tests!(gemini_ipa, Gemini<UnivariateIpa<grumpkin::G1Affine>>);
-    //tests!(zeromorph_ipa, Zeromorph<UnivariateIpa<grumpkin::G1Affine>>);
+    tests!(zeromorph_ipa, Zeromorph<UnivariateIpa<grumpkin::G1Affine>>);
 }

--- a/plonkish_backend/src/pcs/multilinear/zeromorph.rs
+++ b/plonkish_backend/src/pcs/multilinear/zeromorph.rs
@@ -306,9 +306,11 @@ where
             let got = poly.evals().len() - 1;
             return Err(err_too_large_deree("commit", pp.degree(), got));
         }
-        let uni_poly = UnivariatePolynomial::monomial(poly.evals().to_vec());
 
-        UnivariateIpa::commit(pp, &uni_poly)
+        let bases = pp.monomial();
+        Ok(UnivariateIpaCommitment(
+            variable_base_msm(poly.evals(), &bases[..poly.evals().len()]).into(),
+        ))
     }
 
     fn batch_commit<'a>(


### PR DESCRIPTION
This small PR fixes an error in the implementation of `Zeromorph<UnivariateIpa>` that meant the corresponding `protostar` and `sangria` accumulation tests were failing.